### PR TITLE
Enable 'js' feature flag for getrandom used by ahash

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ exclude = ["/assets/"]
 [features]
 default = ["ahash"]
 
+ahash = ["dep:ahash", "dep:getrandom"]
 hot-reloading = ["dep:notify", "dep:crossbeam-channel"]
 macros = ["dep:assets_manager_macros"]
 embedded = ["macros"]
@@ -80,6 +81,12 @@ ab_glyph = { version = "0.2.12", optional = true }
 
 gltf = { version = "1.0", optional = true, default-features = false }
 base64 = { version = "0.22", optional = true }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.2", features = ["js"], optional = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+getrandom = { version = "0.2", optional = true }
 
 
 [dev-dependencies]


### PR DESCRIPTION
This ensures that when building a game for the web with the `ahash` feature it will compile, otherwise, the following error is thrown:

<details>
<summary>Compilation error</summary>
---

```
error: the wasm*-unknown-unknown targets are not supported by default, you may need to enable the "js" feature. For more information see: https://docs.rs/getrandom/#webassembly-support
   --> /home/thomas/.cargo/registry/src/index.crates.io-6f17d22bba15001f/getrandom-0.2.12/src/lib.rs:291:9
    |
291 | /         compile_error!("the wasm*-unknown-unknown targets are not supported by \
292 | |                         default, you may need to enable the \"js\" feature. \
293 | |                         For more information see: \
294 | |                         https://docs.rs/getrandom/#webassembly-support");
    | |________________________________________________________________________^

error[E0433]: failed to resolve: use of undeclared crate or module `imp`
   --> /home/thomas/.cargo/registry/src/index.crates.io-6f17d22bba15001f/getrandom-0.2.12/src/lib.rs:347:9
    |
347 |         imp::getrandom_inner(dest)?;
    |         ^^^ use of undeclared crate or module `imp`

For more information about this error, try `rustc --explain E0433`.
error: could not compile `getrandom` (lib) due to 2 previous errors
```


</details>